### PR TITLE
feat: bump version for release into the wild

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@w3cwebstorage/w3cwebstorage",
-  "version": "0.0.0-development",
+  "version": "0.1.0",
   "description": "Web Storage with reducers",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
Breaking the wall into the public domain. Releasing 0.1.0 supporting only localStorage to NPM #19 