### PR TITLE
feat: change image in markdown to png

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://github.com/w3cwebstorage/w3cwebstorage" target="__blank"><img alt="w3cwebstorage" src="https://github.com/w3cwebstorage/w3cwebstorage/blob/3837597d61164184702430d38bb906df546e4424/logo.svg" width="60" /></a>
+<a href="https://github.com/w3cwebstorage/w3cwebstorage" target="__blank"><img alt="w3cwebstorage" src="https://raw.githubusercontent.com/w3cwebstorage/w3cwebstorage/master/logo.png" width="100" /></a>
 
 # w3cwebstorage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@w3cwebstorage/w3cwebstorage",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Web Storage with reducers",
   "main": "./dist/index.cjs.js",
   "module": "./dist/index.js",

--- a/src/localstorage/README.md
+++ b/src/localstorage/README.md
@@ -1,4 +1,4 @@
-<a href="https://github.com/w3cwebstorage/w3cwebstorage" target="__blank"><img alt="w3cwebstorage" src="https://github.com/w3cwebstorage/w3cwebstorage/blob/3837597d61164184702430d38bb906df546e4424/logo.svg" width="60" /></a>
+<a href="https://github.com/w3cwebstorage/w3cwebstorage" target="__blank"><img alt="w3cwebstorage" src="https://raw.githubusercontent.com/w3cwebstorage/w3cwebstorage/master/logo.png" width="100" /></a>
 
 # w3cwebstorage - localstorage
 


### PR DESCRIPTION
Make markdown use png instead of svg as NPM markdown does not support svg. Bump version to v0.1.2 for release #27